### PR TITLE
feat: many to many relations

### DIFF
--- a/integration/schema.ts
+++ b/integration/schema.ts
@@ -75,6 +75,11 @@ const zeroSchema = createZeroSchema(drizzleSchema, {
       optional_uuid: true,
     },
   },
+  manyToMany: {
+    user: {
+      mediums: ["message", "medium"],
+    },
+  },
 });
 
 export const schema = createSchema(zeroSchema);

--- a/integration/tests/integration.test.ts
+++ b/integration/tests/integration.test.ts
@@ -87,6 +87,23 @@ describe("relationships", () => {
     preloadedMessages.cleanup();
   });
 
+  test("can query many-to-many relationships", async () => {
+    const zero = await getNewZero();
+
+    const q = zero.query.user.related("mediums").one();
+
+    const preloadedUsers = await q.preload();
+    await preloadedUsers.complete;
+
+    const user = await q.one().run();
+
+    expect(user?.mediums).toHaveLength(2);
+    expect(user?.mediums[0]?.name).toBe("email");
+    expect(user?.mediums[1]?.name).toBe("whatsapp");
+
+    preloadedUsers.cleanup();
+  });
+
   test("can insert messages", async () => {
     const zero = await getNewZero();
 
@@ -269,14 +286,27 @@ describe("types", () => {
     expect(dbResult?.uuidField).toBeDefined();
     expect(dbResult?.varcharField).toStrictEqual("varchar2");
     expect(dbResult?.booleanField).toStrictEqual(true);
-    expect(dbResult?.timestampField?.toISOString()).toStrictEqual(currentDate.toISOString());
-    expect(dbResult?.timestampTzField?.toISOString()).toStrictEqual(currentDate.toISOString());
-    expect(dbResult?.timestampModeDate?.toISOString()).toStrictEqual(currentDate.toISOString());
-    expect(dbResult?.timestampModeString).toContain(currentDate.toISOString().split("T")[0]);
-    expect(dbResult?.dateField).toStrictEqual(currentDate.toISOString().split("T")[0]);
+    expect(dbResult?.timestampField?.toISOString()).toStrictEqual(
+      currentDate.toISOString(),
+    );
+    expect(dbResult?.timestampTzField?.toISOString()).toStrictEqual(
+      currentDate.toISOString(),
+    );
+    expect(dbResult?.timestampModeDate?.toISOString()).toStrictEqual(
+      currentDate.toISOString(),
+    );
+    expect(dbResult?.timestampModeString).toContain(
+      currentDate.toISOString().split("T")[0],
+    );
+    expect(dbResult?.dateField).toStrictEqual(
+      currentDate.toISOString().split("T")[0],
+    );
     expect(dbResult?.jsonField).toStrictEqual({ key: "value" });
     expect(dbResult?.jsonbField).toStrictEqual({ key: "value" });
-    expect(dbResult?.typedJsonField).toStrictEqual({ theme: "light", fontSize: 16 });
+    expect(dbResult?.typedJsonField).toStrictEqual({
+      theme: "light",
+      fontSize: 16,
+    });
     expect(dbResult?.statusField).toStrictEqual("active");
 
     expect(dbResult?.smallSerialField).toStrictEqual(2);

--- a/integration/tests/utils.ts
+++ b/integration/tests/utils.ts
@@ -84,7 +84,7 @@ export const seed = async () => {
     id: "5",
     body: "Thomas!",
     senderId: "1",
-    mediumId: "2",
+    mediumId: "4",
     metadata: { key: "value5" },
   });
 

--- a/integration/zero-schema.json
+++ b/integration/zero-schema.json
@@ -356,6 +356,26 @@
           }
         },
         "relationships": {
+          "mediums": [
+            {
+              "sourceField": [
+                "id"
+              ],
+              "destField": [
+                "senderId"
+              ],
+              "destSchema": "message"
+            },
+            {
+              "sourceField": [
+                "mediumId"
+              ],
+              "destField": [
+                "id"
+              ],
+              "destSchema": "medium"
+            }
+          ],
           "messages": {
             "sourceField": [
               "id"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drizzle-zero",
-  "version": "0.1.11",
+  "version": "0.2.0",
   "description": "Generate Zero schemas from Drizzle ORM schemas",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drizzle-zero",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Generate Zero schemas from Drizzle ORM schemas",
   "type": "module",
   "scripts": {

--- a/src/db.ts
+++ b/src/db.ts
@@ -2,6 +2,12 @@ import type { Table } from "drizzle-orm";
 import { getTableName, is } from "drizzle-orm";
 import { getTableConfig, PgTable } from "drizzle-orm/pg-core";
 
+/**
+ * Get the table config for a given table.
+ * 
+ * @param table - The table to get the config for
+ * @returns The table config
+ */
 export const getTableConfigForDatabase = <T extends Table>(table: T) => {
   if (is(table, PgTable)) {
     return getTableConfig(table);

--- a/src/drizzle-to-zero.ts
+++ b/src/drizzle-to-zero.ts
@@ -1,3 +1,9 @@
+import type { JSONValue } from "@rocicorp/zero";
+
+/**
+ * Represents the basic data types supported by Drizzle ORM.
+ * These are the fundamental types that can be used in table column definitions.
+ */
 type DrizzleDataType =
   | "number"
   | "bigint"
@@ -6,6 +12,10 @@ type DrizzleDataType =
   | "string"
   | "json";
 
+/**
+ * Maps Drizzle data types to their corresponding Zero schema types.
+ * This is a constant mapping that ensures type safety when converting between the two systems.
+ */
 export const drizzleDataTypeToZeroType = {
   number: "number",
   bigint: "number",
@@ -15,14 +25,41 @@ export const drizzleDataTypeToZeroType = {
   json: "json",
 } as const satisfies Record<DrizzleDataType, string>;
 
+/**
+ * Type representation of the Drizzle to Zero type mapping.
+ * Extracts the type information from the drizzleDataTypeToZeroType constant.
+ */
 export type DrizzleDataTypeToZeroType = typeof drizzleDataTypeToZeroType;
 
+/**
+ * Represents specific Postgres column types supported by Drizzle ORM.
+ * These are more specialized types that need custom handling when converting to Zero.
+ */
 type DrizzleColumnType = "PgNumeric" | "PgDateString" | "PgTimestampString";
 
+/**
+ * Maps Postgres-specific Drizzle column types to their corresponding Zero schema types.
+ * Handles special cases where Postgres types need specific Zero type representations.
+ */
 export const drizzleColumnTypeToZeroType = {
   PgNumeric: "number",
   PgDateString: "number",
   PgTimestampString: "number",
 } as const satisfies Record<DrizzleColumnType, string>;
 
+/**
+ * Type representation of the Postgres-specific Drizzle to Zero type mapping.
+ * Extracts the type information from the drizzleColumnTypeToZeroType constant.
+ */
 export type DrizzleColumnTypeToZeroType = typeof drizzleColumnTypeToZeroType;
+
+/**
+ * Maps Zero schema types to their corresponding TypeScript types.
+ */
+export type ZeroTypeToTypescriptType = {
+  number: number;
+  boolean: boolean;
+  date: string;
+  string: string;
+  json: JSONValue;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,10 @@
 import { createZeroSchema, type CreateZeroSchema } from "./relations";
-import { createZeroTableSchema, type CreateZeroTableSchema } from "./tables";
-import type { ColumnsConfig, ZeroColumns } from "./types";
+import {
+  createZeroTableSchema,
+  type CreateZeroTableSchema,
+  type ColumnsConfig,
+  type ZeroColumns,
+} from "./tables";
 
 export {
   createZeroSchema,

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -5,17 +5,155 @@ import {
   drizzleColumnTypeToZeroType,
   type DrizzleDataTypeToZeroType,
   drizzleDataTypeToZeroType,
+  type ZeroTypeToTypescriptType,
 } from "./drizzle-to-zero";
 import type {
-  ColumnsConfig,
+  ColumnName,
+  ColumnNames,
+  Columns,
   FindPrimaryKeyFromTable,
   Flatten,
   TableName,
-  ZeroColumns,
-  ZeroTypeToTypescriptType,
 } from "./types";
 import { typedEntries } from "./util";
 
+/**
+ * Represents a column definition from a Drizzle table, filtered by column name.
+ * @template TTable The Drizzle table type
+ * @template K The column name to filter by
+ */
+type ColumnDefinition<TTable extends Table, K extends ColumnNames<TTable>> = {
+  [C in keyof Columns<TTable>]: ColumnName<Columns<TTable>[C]> extends K
+    ? Columns<TTable>[C]
+    : never;
+}[keyof Columns<TTable>];
+
+/**
+ * The type override for a column.
+ * Used to customize how a Drizzle column is mapped to a Zero schema.
+ * @template TCustomType The TypeScript type that corresponds to the Zero type
+ */
+type TypeOverride<TCustomType> = {
+  readonly type: "string" | "number" | "boolean" | "json";
+  readonly optional: boolean;
+  readonly customType: TCustomType;
+  readonly kind?: "enum";
+};
+
+/**
+ * Configuration for specifying which columns to include in the Zero schema and how to map them.
+ * @template TTable The Drizzle table type
+ */
+export type ColumnsConfig<TTable extends Table> = {
+  /**
+   * The columns to include in the Zero schema.
+   * Set to true to use default mapping, or provide a TypeOverride for custom mapping.
+   */
+  readonly [KColumn in ColumnNames<TTable>]?:
+    | boolean
+    | TypeOverride<
+        ZeroTypeToTypescriptType[DrizzleDataTypeToZeroType[Columns<TTable>[KColumn]["dataType"]]]
+      >;
+};
+
+/**
+ * Maps a Drizzle column type to its corresponding Zero type.
+ * @template TTable The Drizzle table type
+ * @template KColumn The column name
+ * @template CD The column definition type
+ */
+type ZeroMappedColumnType<
+  TTable extends Table,
+  KColumn extends ColumnNames<TTable>,
+  CD extends ColumnDefinition<TTable, KColumn>["_"] = ColumnDefinition<
+    TTable,
+    KColumn
+  >["_"],
+> = CD extends {
+  columnType: keyof DrizzleColumnTypeToZeroType;
+}
+  ? DrizzleColumnTypeToZeroType[CD["columnType"]]
+  : DrizzleDataTypeToZeroType[CD["dataType"]];
+
+/**
+ * Maps a Drizzle column to its corresponding TypeScript type in Zero.
+ * Handles special cases like enums and custom types.
+ * @template TTable The Drizzle table type
+ * @template KColumn The column name
+ * @template CD The column definition type
+ */
+type ZeroMappedCustomType<
+  TTable extends Table,
+  KColumn extends ColumnNames<TTable>,
+  CD extends ColumnDefinition<TTable, KColumn>["_"] = ColumnDefinition<
+    TTable,
+    KColumn
+  >["_"],
+> = CD extends {
+  columnType: "PgEnumColumn";
+}
+  ? CD["data"]
+  : CD extends { $type: any }
+    ? CD["$type"]
+    : ZeroTypeToTypescriptType[ZeroMappedColumnType<TTable, KColumn>];
+
+/**
+ * Defines the structure of a column in the Zero schema.
+ * @template TTable The Drizzle table type
+ * @template KColumn The column name
+ * @template CD The column definition type
+ */
+type ZeroColumnDefinition<
+  TTable extends Table,
+  KColumn extends ColumnNames<TTable>,
+  CD extends ColumnDefinition<TTable, KColumn>["_"] = ColumnDefinition<
+    TTable,
+    KColumn
+  >["_"],
+> = Readonly<
+  {
+    readonly optional: CD extends {
+      hasDefault: true;
+      hasRuntimeDefault: false;
+    }
+      ? true
+      : CD extends { notNull: true }
+        ? false
+        : true;
+    readonly type: ZeroMappedColumnType<TTable, KColumn>;
+    readonly customType: ZeroMappedCustomType<TTable, KColumn>;
+  } & (CD extends { columnType: "PgEnumColumn" }
+    ? { readonly kind: "enum" }
+    : {})
+>;
+
+/**
+ * Maps the columns configuration to their Zero schema definitions.
+ * @template TTable The Drizzle table type
+ * @template TColumnConfig The columns configuration
+ */
+export type ZeroColumns<
+  TTable extends Table,
+  TColumnConfig extends ColumnsConfig<TTable>,
+> = {
+  readonly [KColumn in keyof TColumnConfig as TColumnConfig[KColumn] extends
+    | true
+    | TypeOverride<any>
+    ? KColumn
+    : never]: KColumn extends ColumnNames<TTable>
+    ? TColumnConfig[KColumn] extends TypeOverride<any>
+      ? TColumnConfig[KColumn]
+      : TColumnConfig[KColumn] extends true
+        ? ZeroColumnDefinition<TTable, KColumn>
+        : never
+    : never;
+};
+
+/**
+ * Represents the complete Zero schema for a Drizzle table.
+ * @template TTable The Drizzle table type
+ * @template TColumnConfig The columns configuration
+ */
 type CreateZeroTableSchema<
   TTable extends Table = Table,
   TColumnConfig extends ColumnsConfig<TTable> = ColumnsConfig<TTable>,
@@ -25,6 +163,15 @@ type CreateZeroTableSchema<
   readonly columns: ZeroColumns<TTable, TColumnConfig>;
 }>;
 
+/**
+ * Creates a Zero schema from a Drizzle table definition.
+ * @template TTable The Drizzle table type
+ * @template TColumnConfig The columns configuration type
+ * @param table The Drizzle table instance
+ * @param columns Configuration specifying which columns to include and how to map them
+ * @returns A Zero schema definition for the table
+ * @throws {Error} If primary key configuration is invalid or column types are unsupported
+ */
 const createZeroTableSchema = <
   TTable extends Table,
   TColumnConfig extends ColumnsConfig<TTable>,

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -17,18 +17,21 @@ import type {
 import { typedEntries } from "./util";
 
 type CreateZeroTableSchema<
-  T extends Table = Table,
-  C extends ColumnsConfig<T> = ColumnsConfig<T>,
+  TTable extends Table = Table,
+  TColumnConfig extends ColumnsConfig<TTable> = ColumnsConfig<TTable>,
 > = Flatten<{
-  readonly tableName: TableName<T>;
-  readonly primaryKey: FindPrimaryKeyFromTable<T>;
-  readonly columns: ZeroColumns<T, C>;
+  readonly tableName: TableName<TTable>;
+  readonly primaryKey: FindPrimaryKeyFromTable<TTable>;
+  readonly columns: ZeroColumns<TTable, TColumnConfig>;
 }>;
 
-const createZeroTableSchema = <T extends Table, C extends ColumnsConfig<T>>(
-  table: T,
-  columns: C,
-): CreateZeroTableSchema<T, C> => {
+const createZeroTableSchema = <
+  TTable extends Table,
+  TColumnConfig extends ColumnsConfig<TTable>,
+>(
+  table: TTable,
+  columns: TColumnConfig,
+): CreateZeroTableSchema<TTable, TColumnConfig> => {
   const tableColumns = getTableColumns(table);
   const tableConfig = getTableConfigForDatabase(table);
 
@@ -38,7 +41,7 @@ const createZeroTableSchema = <T extends Table, C extends ColumnsConfig<T>>(
     (acc, [_key, column]) => {
       const name = column.name;
 
-      const columnConfig = columns[name as keyof C];
+      const columnConfig = columns[name as keyof TColumnConfig];
 
       if (
         typeof columnConfig !== "boolean" &&
@@ -105,7 +108,7 @@ const createZeroTableSchema = <T extends Table, C extends ColumnsConfig<T>>(
         [name]: schemaValue,
       };
     },
-    {} as ZeroColumns<T, C>,
+    {} as ZeroColumns<TTable, TColumnConfig>,
   );
 
   const tableName = getTableName(table);
@@ -126,8 +129,8 @@ const createZeroTableSchema = <T extends Table, C extends ColumnsConfig<T>>(
   return {
     tableName,
     columns: columnsMapped,
-    primaryKey: primaryKeys as unknown as FindPrimaryKeyFromTable<T>,
-  } as unknown as CreateZeroTableSchema<T, C>;
+    primaryKey: primaryKeys as unknown as FindPrimaryKeyFromTable<TTable>,
+  } as unknown as CreateZeroTableSchema<TTable, TColumnConfig>;
 };
 
 export { createZeroTableSchema, type CreateZeroTableSchema };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,29 +1,47 @@
-import type { JSONValue } from "@rocicorp/zero";
-import type { Column, Table } from "drizzle-orm";
-import type {
-  DrizzleColumnTypeToZeroType,
-  DrizzleDataTypeToZeroType,
-} from "./drizzle-to-zero";
+import type { Column, Relations, Table } from "drizzle-orm";
 
+/**
+ * Extracts the table name from a Drizzle table type.
+ * @template TTable The Drizzle table type
+ */
 export type TableName<TTable extends Table> = TTable["_"]["name"];
+
+/**
+ * Extracts the column name from a Drizzle column type.
+ * @template TColumn The Drizzle column type
+ */
 export type ColumnName<TColumn extends Column> = TColumn["_"]["name"];
 
+/**
+ * Gets all columns from a Drizzle table type.
+ * @template TTable The Drizzle table type
+ */
 export type Columns<TTable extends Table> = TTable["_"]["columns"];
+
+/**
+ * Gets all column names from a Drizzle table type.
+ * @template TTable The Drizzle table type
+ */
 export type ColumnNames<TTable extends Table> = ColumnName<
   Columns<TTable>[keyof Columns<TTable>]
 >;
-type ColumnDefinition<TTable extends Table, K extends ColumnNames<TTable>> = {
-  [C in keyof Columns<TTable>]: ColumnName<Columns<TTable>[C]> extends K
-    ? Columns<TTable>[C]
-    : never;
-}[keyof Columns<TTable>];
 
+/**
+ * Helper type that extracts primary key columns from a table.
+ * @template T The Drizzle table type
+ */
 type PrimaryKeyColumns<T extends Table> = {
   [K in keyof Columns<T>]: Columns<T>[K]["_"]["isPrimaryKey"] extends true
     ? ColumnName<Columns<T>[K]>
     : never;
 }[keyof Columns<T>];
 
+/**
+ * Finds the primary key(s) from a table. Returns either:
+ * - A readonly tuple of the primary key column name if one exists
+ * - A readonly array of at least one string if no primary key is defined
+ * @template T The Drizzle table type
+ */
 export type FindPrimaryKeyFromTable<T extends Table> = [
   PrimaryKeyColumns<T>,
 ] extends [never]
@@ -31,109 +49,71 @@ export type FindPrimaryKeyFromTable<T extends Table> = [
   : readonly [PrimaryKeyColumns<T>];
 
 /**
- * The type override for a column.
+ * Finds relations defined for a specific table in the Drizzle schema.
+ * @template TDrizzleSchema The complete Drizzle schema
+ * @template TTable The table to find relations for
  */
-type TypeOverride<TCustomType> = {
-  readonly type: "string" | "number" | "boolean" | "json";
-  readonly optional: boolean;
-  readonly customType: TCustomType;
-  readonly kind?: "enum";
-};
-
-/**
- * The configuration for the columns to include in the Zero schema.
- */
-export type ColumnsConfig<TTable extends Table> = {
-  /**
-   * The columns to include in the Zero schema.
-   */
-  readonly [KColumn in ColumnNames<TTable>]?:
-    | boolean
-    | TypeOverride<
-        ZeroTypeToTypescriptType[DrizzleDataTypeToZeroType[Columns<TTable>[KColumn]["dataType"]]]
-      >;
-};
-
-export type ZeroTypeToTypescriptType = {
-  number: number;
-  boolean: boolean;
-  date: string;
-  string: string;
-  json: JSONValue;
-};
-
-type ZeroMappedColumnType<
+export type FindRelationsForTable<
+  TDrizzleSchema extends Record<string, unknown>,
   TTable extends Table,
-  KColumn extends ColumnNames<TTable>,
-  CD extends ColumnDefinition<TTable, KColumn>["_"] = ColumnDefinition<
-    TTable,
-    KColumn
-  >["_"],
-> = CD extends {
-  columnType: keyof DrizzleColumnTypeToZeroType;
-}
-  ? DrizzleColumnTypeToZeroType[CD["columnType"]]
-  : DrizzleDataTypeToZeroType[CD["dataType"]];
-
-type ZeroMappedCustomType<
-  TTable extends Table,
-  KColumn extends ColumnNames<TTable>,
-  CD extends ColumnDefinition<TTable, KColumn>["_"] = ColumnDefinition<
-    TTable,
-    KColumn
-  >["_"],
-> = CD extends {
-  columnType: "PgEnumColumn";
-}
-  ? CD["data"]
-  : CD extends { $type: any }
-    ? CD["$type"]
-    : ZeroTypeToTypescriptType[ZeroMappedColumnType<TTable, KColumn>];
-
-type ZeroColumnDefinition<
-  TTable extends Table,
-  KColumn extends ColumnNames<TTable>,
-  CD extends ColumnDefinition<TTable, KColumn>["_"] = ColumnDefinition<
-    TTable,
-    KColumn
-  >["_"],
-> = Readonly<
-  {
-    readonly optional: CD extends {
-      hasDefault: true;
-      // Zero doesn't support runtime defaults yet
-      hasRuntimeDefault: false;
-    }
-      ? true
-      : CD extends { notNull: true }
-        ? false
-        : true;
-    readonly type: ZeroMappedColumnType<TTable, KColumn>;
-    readonly customType: ZeroMappedCustomType<TTable, KColumn>;
-  } & (CD extends { columnType: "PgEnumColumn" }
-    ? { readonly kind: "enum" }
-    : {})
+> = Extract<
+  TDrizzleSchema[{
+    [P in keyof TDrizzleSchema]: TDrizzleSchema[P] extends Relations<
+      TableName<TTable>
+    >
+      ? P
+      : never;
+  }[keyof TDrizzleSchema]],
+  Relations<TableName<TTable>>
 >;
 
-export type ZeroColumns<
-  TTable extends Table,
-  TColumnConfig extends ColumnsConfig<TTable>,
-> = {
-  readonly [KColumn in keyof TColumnConfig as TColumnConfig[KColumn] extends
-    | true
-    | TypeOverride<any>
-    ? KColumn
-    : never]: KColumn extends ColumnNames<TTable>
-    ? TColumnConfig[KColumn] extends TypeOverride<any>
-      ? TColumnConfig[KColumn]
-      : TColumnConfig[KColumn] extends true
-        ? ZeroColumnDefinition<TTable, KColumn>
-        : never
-    : never;
-};
+/**
+ * Type guard that checks if a type is a Table with a specific name.
+ * @template T The type to check
+ * @template Name The name to check for
+ */
+type IsTableWithName<T, Name extends string> = T extends { _: { name: Name } }
+  ? T extends Table<any>
+    ? true
+    : false
+  : false;
 
+/**
+ * Finds a table in the schema by its name.
+ * @template TDrizzleSchema The complete Drizzle schema
+ * @template Name The name of the table to find
+ */
+export type FindTableByName<
+  TDrizzleSchema extends Record<string, unknown>,
+  Name extends string,
+> = Extract<
+  {
+    [P in keyof TDrizzleSchema]: IsTableWithName<
+      TDrizzleSchema[P],
+      Name
+    > extends true
+      ? TDrizzleSchema[P]
+      : never;
+  }[keyof TDrizzleSchema],
+  Table<any>
+>;
+
+/**
+ * Extracts the configuration type from a Relations type.
+ * @template T The Relations type to extract config from
+ */
+export type RelationsConfig<T extends Relations> = ReturnType<T["config"]>;
+
+/**
+ * Utility type that flattens an object type by removing any intermediate interfaces.
+ * @template T The type to flatten
+ */
 export type Flatten<T> = {
   [K in keyof T]: T[K];
 } & {};
 
+/**
+ * Utility type that ensures an array has at least one element.
+ * @template T The type of elements in the array
+ */
 export type AtLeastOne<T> = [T, ...T[]];

--- a/tests/schemas/many-to-many-duplicate-relationship.zero.ts
+++ b/tests/schemas/many-to-many-duplicate-relationship.zero.ts
@@ -5,31 +5,28 @@ import {
   type Schema,
 } from "@rocicorp/zero";
 import { createZeroSchema } from "../../src";
-import * as oneToOne2 from "./one-to-one-2.schema";
+import * as manyToMany from "./many-to-many.schema";
 
 export const schema = createSchema(
-  createZeroSchema(oneToOne2, {
-    version: 2.1,
+  createZeroSchema(manyToMany, {
+    version: 1,
     tables: {
       user: {
         id: true,
         name: true,
-        partner: true,
       },
-      medium: {
+      group: {
         id: true,
         name: true,
       },
-      message: {
-        id: true,
-        senderId: true,
-        mediumId: true,
-        body: true,
+      users_to_group: {
+        user_id: true,
+        group_id: true,
       },
     },
     manyToMany: {
       user: {
-        mediums: ["message", "medium"],
+        usersToGroups: ["users_to_group", "group"],
       },
     },
   }),
@@ -37,14 +34,7 @@ export const schema = createSchema(
 
 export const permissions = definePermissions<{}, Schema>(schema, () => {
   return {
-    medium: {
-      row: {
-        insert: ANYONE_CAN,
-        update: ANYONE_CAN,
-        delete: ANYONE_CAN,
-      },
-    },
-    message: {
+    group: {
       row: {
         insert: ANYONE_CAN,
         update: ANYONE_CAN,
@@ -52,6 +42,13 @@ export const permissions = definePermissions<{}, Schema>(schema, () => {
       },
     },
     user: {
+      row: {
+        insert: ANYONE_CAN,
+        update: ANYONE_CAN,
+        delete: ANYONE_CAN,
+      },
+    },
+    users_to_group: {
       row: {
         insert: ANYONE_CAN,
         update: ANYONE_CAN,

--- a/tests/schemas/many-to-many-missing-foreign-key.schema.ts
+++ b/tests/schemas/many-to-many-missing-foreign-key.schema.ts
@@ -13,12 +13,8 @@ export const usersRelations = relations(users, ({ many }) => ({
 export const usersToGroups = pgTable(
   "users_to_group",
   {
-    userId: text("user_id")
-      .notNull()
-      .references(() => users.id),
-    groupId: text("group_id")
-      .notNull()
-      .references(() => groups.id),
+    userId: text("user_id").notNull(),
+    groupId: text("group_id").notNull(),
   },
   (t) => [primaryKey({ columns: [t.userId, t.groupId] })],
 );

--- a/tests/schemas/many-to-many-missing-foreign-key.zero.ts
+++ b/tests/schemas/many-to-many-missing-foreign-key.zero.ts
@@ -5,31 +5,28 @@ import {
   type Schema,
 } from "@rocicorp/zero";
 import { createZeroSchema } from "../../src";
-import * as oneToOne2 from "./one-to-one-2.schema";
+import * as manyToManyForeignKey from "./many-to-many-missing-foreign-key.schema";
 
 export const schema = createSchema(
-  createZeroSchema(oneToOne2, {
-    version: 2.1,
+  createZeroSchema(manyToManyForeignKey, {
+    version: 1,
     tables: {
       user: {
         id: true,
         name: true,
-        partner: true,
       },
-      medium: {
+      group: {
         id: true,
         name: true,
       },
-      message: {
-        id: true,
-        senderId: true,
-        mediumId: true,
-        body: true,
+      users_to_group: {
+        user_id: true,
+        group_id: true,
       },
     },
     manyToMany: {
       user: {
-        mediums: ["message", "medium"],
+        groups: ["users_to_group", "group"],
       },
     },
   }),
@@ -37,14 +34,7 @@ export const schema = createSchema(
 
 export const permissions = definePermissions<{}, Schema>(schema, () => {
   return {
-    medium: {
-      row: {
-        insert: ANYONE_CAN,
-        update: ANYONE_CAN,
-        delete: ANYONE_CAN,
-      },
-    },
-    message: {
+    group: {
       row: {
         insert: ANYONE_CAN,
         update: ANYONE_CAN,
@@ -52,6 +42,13 @@ export const permissions = definePermissions<{}, Schema>(schema, () => {
       },
     },
     user: {
+      row: {
+        insert: ANYONE_CAN,
+        update: ANYONE_CAN,
+        delete: ANYONE_CAN,
+      },
+    },
+    users_to_group: {
       row: {
         insert: ANYONE_CAN,
         update: ANYONE_CAN,

--- a/tests/schemas/many-to-many.zero.ts
+++ b/tests/schemas/many-to-many.zero.ts
@@ -24,6 +24,11 @@ export const schema = createSchema(
         group_id: true,
       },
     },
+    manyToMany: {
+      user: {
+        groups: ["users_to_group", "group"],
+      },
+    },
   }),
 );
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -38,56 +38,29 @@ export function expectTableSchemaDeepEqual<S extends ZeroTableSchema>(
 
       if (expected.relationships) {
         for (const key of Object.keys(expected.relationships)) {
-          expect(
-            (
-              actual.relationships?.[
-                key as keyof typeof actual.relationships
-              ] as {
-                sourceField: string;
-              }
-            )?.sourceField,
-          ).toStrictEqual(
-            (
-              expected.relationships?.[
-                key as keyof typeof expected.relationships
-              ] as {
-                sourceField: string;
-              }
-            )?.sourceField,
-          );
+          const expectedRelations = Array.isArray(expected.relationships[key])
+            ? expected.relationships[key]
+            : [expected.relationships[key]];
 
-          expect(
-            (
-              actual.relationships?.[
-                key as keyof typeof actual.relationships
-              ] as {
-                destField: string;
-              }
-            )?.destField,
-          ).toStrictEqual(
-            (
-              expected.relationships?.[
-                key as keyof typeof expected.relationships
-              ] as {
-                destField: string;
-              }
-            )?.destField,
-          );
+          const actualRelations = Array.isArray(actual.relationships?.[key])
+            ? actual.relationships?.[key]
+            : [actual.relationships?.[key]];
 
-          expectTableSchemaDeepEqual(
-            (
-              actual.relationships?.[
-                key as keyof typeof actual.relationships
-              ] as { destSchema: () => ZeroTableSchema }
-            )?.destSchema(),
-          ).toEqual(
-            (
-              expected.relationships?.[
-                key as keyof typeof expected.relationships
-              ] as { destSchema: () => ZeroTableSchema }
-            )?.destSchema(),
-            depth + 1,
-          );
+          expect(actualRelations).toHaveLength(expectedRelations.length);
+
+          for (let i = 0; i < expectedRelations.length; i++) {
+            expect(actualRelations[i]?.sourceField).toStrictEqual(
+              expectedRelations[i]?.sourceField,
+            );
+
+            expect(actualRelations[i]?.destField).toStrictEqual(
+              expectedRelations[i]?.destField,
+            );
+
+            expectTableSchemaDeepEqual(
+              expectedRelations[i]?.destSchema(),
+            ).toEqual(actualRelations[i]?.destSchema(), depth + 1);
+          }
         }
       }
     },


### PR DESCRIPTION
Added many to many relations through a junction table:

```tsx
export const schema = createSchema(
  createZeroSchema(drizzleSchema, {
    version: 1,
    tables: {
      user: {
        id: true,
        name: true,
      },
      group: {
        id: true,
        name: true,
      },
      users_to_group: {
        user_id: true,
        group_id: true,
      },
    },
    manyToMany: {
      // The origin table to define the many-to-many relationship on
      user: {
        // The key is the relation name and value is [junction table, target table]
        groups: ["users_to_group", "group"],
      },
    },
  }),
);
```