### PR TITLE
Add Array support

### DIFF
--- a/src/drizzle-to-zero.ts
+++ b/src/drizzle-to-zero.ts
@@ -36,7 +36,8 @@ type DrizzleColumnType =
   | "PgJson"
   | "PgNumeric"
   | "PgDateString"
-  | "PgTimestampString";
+  | "PgTimestampString"
+  | "PgArray";
 
 /**
  * Maps Postgres-specific Drizzle column types to their corresponding Zero schema types.
@@ -53,6 +54,7 @@ export const drizzleColumnTypeToZeroType = {
   PgNumeric: "number",
   PgDateString: "number",
   PgTimestampString: "number",
+  PgArray: "json",
 } as const satisfies Record<DrizzleColumnType, string>;
 
 /**

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -107,9 +107,14 @@ type ZeroMappedCustomType<
         data: string;
       }
     ? CD["data"]
-    : CD extends { $type: any }
-      ? CD["$type"]
-      : ZeroTypeToTypescriptType[ZeroMappedColumnType<TTable, KColumn>];
+    : CD extends {
+        columnType: "PgArray";
+        data: infer TArrayData;
+      }
+      ? TArrayData
+      : CD extends { $type: any }
+        ? CD["$type"]
+        : ZeroTypeToTypescriptType[ZeroMappedColumnType<TTable, KColumn>];
 
 /**
  * Defines the structure of a column in the Zero schema.


### PR DESCRIPTION
Array support was added by mapping the PgArray column type to json in src/drizzle-to-zero.ts.

- src/tables.ts was updated to correctly infer TypeScript types for array data within ZeroMappedCustomType.
- tests/tables.test.ts was expanded with comprehensive array tests covering various base types, custom types, and default values.
- The mapping was refined to specifically target PgArray to prevent misinterpreting other types (e.g., PgPointTuple) as arrays.